### PR TITLE
通知のポーリングレートを落とす

### DIFF
--- a/app/go/app_handlers.go
+++ b/app/go/app_handlers.go
@@ -770,7 +770,7 @@ func appGetNotification(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, &appGetNotificationResponse{
 				// 状態変更から3秒以内に通知されている必要があるため、2秒後にリトライする
 				// see: https://gist.github.com/wtks/8eadf471daf7cb59942de02273ce7884#通知エンドポイント
-				RetryAfterMs: 1000,
+				RetryAfterMs: 2000,
 			})
 			return
 		}
@@ -819,7 +819,7 @@ func appGetNotification(w http.ResponseWriter, r *http.Request) {
 		},
 		// 状態変更から3秒以内に通知されている必要があるため、2秒後にリトライする
 		// see: https://gist.github.com/wtks/8eadf471daf7cb59942de02273ce7884#通知エンドポイント
-		RetryAfterMs: 1000,
+		RetryAfterMs: 2000,
 	}
 
 	if ride.ChairID.Valid {

--- a/app/go/chair_handlers.go
+++ b/app/go/chair_handlers.go
@@ -203,7 +203,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, &chairGetNotificationResponse{
 				// 状態変更から3秒以内に通知されている必要があるため、2秒後にリトライする
 				// see: https://gist.github.com/wtks/8eadf471daf7cb59942de02273ce7884#通知エンドポイント
-				RetryAfterMs: 1000,
+				RetryAfterMs: 2000,
 			})
 			return
 		}
@@ -265,7 +265,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 		},
 		// 状態変更から3秒以内に通知されている必要があるため、2秒後にリトライする
 		// see: https://gist.github.com/wtks/8eadf471daf7cb59942de02273ce7884#通知エンドポイント
-		RetryAfterMs: 1000,
+		RetryAfterMs: 2000,
 	})
 }
 


### PR DESCRIPTION
see: https://gist.github.com/wtks/8eadf471daf7cb59942de02273ce7884#通知エンドポイント

> 状態が変更されてから3秒以内に通知されていることが期待されます。

なので2秒ごとに通知を確認するように変更